### PR TITLE
fix: uid optional

### DIFF
--- a/docs/event/msg.md
+++ b/docs/event/msg.md
@@ -32,10 +32,10 @@ message Contact {
 其中的`scene`表示来自何方的类型，而`peer`则为来自何方，他有以下几种情况：
 
 - **GROUP**：`peer`为群号。
-- **FRIEND**：`peer`为QQ号或者用户`uid`。
+- **FRIEND**：`peer`为QQ号。
 - **GUILD**：`peer`为频道号，`sub_peer`为子频道号。
 - **NEARBY**：`peer`为QQ号或者用户`tiny_id`。
-- **STRANGER**：`peer`为QQ号或者用户`uid`。
+- **STRANGER**：`peer`为QQ号。
 - **STRANGER_FROM_GROUP**：`peer`为QQ，`sub_peer`为群号。
 
 ## 消息事件

--- a/docs/request/common.md
+++ b/docs/request/common.md
@@ -28,22 +28,21 @@ enum Scene {
 
 message Contact {
   Scene scene = 1;
-  string peer = 2; // GROUP: group_id, FRIEND|STRANGER_FROM_GROUP|NEARBY|STRANGER: uid, GUILD: guild_id
+  string peer = 2; // GROUP: group_id, FRIEND|STRANGER_FROM_GROUP|NEARBY|STRANGER: qq, GUILD: guild_id
   optional string sub_peer = 3; // GUILD: channel_id, STRANGER_FROM_GROUP: group_id
 }
 
 message Sender {
-  uint64 uin = 1;
-  optional string uid = 2;
-  optional string nick = 3;
+  string user_id = 1;
+  optional string nick = 2;
 }
 ```
 
 其中的`scene`表示来自何方的类型，而`peer`则为来自何方，他有以下几种情况：
 
 - **GROUP**：`peer`为群号。
-- **FRIEND**：`peer`为QQ号或者用户`uid`。
+- **FRIEND**：`peer`为QQ号。
 - **GUILD**：`peer`为频道号，`sub_peer`为子频道号。
 - **NEARBY**：`peer`为QQ号或者用户`tiny_id`。
-- **STRANGER**：`peer`为QQ号或者用户`uid`。
+- **STRANGER**：`peer`为QQ号。
 - **STRANGER_FROM_GROUP**：`peer`为QQ，`sub_peer`为群号。

--- a/docs/request/common.md
+++ b/docs/request/common.md
@@ -33,8 +33,8 @@ message Contact {
 }
 
 message Sender {
-  string uid = 1;
-  optional uint64 uin = 2;
+  uint64 uin = 1;
+  optional string uid = 2;
   optional string nick = 3;
 }
 ```

--- a/docs/request/core.md
+++ b/docs/request/core.md
@@ -48,12 +48,17 @@ message GetVersionResponse {
 
 ```protobuf
 message DownloadFileRequest {
+  message Header {
+    string key = 1; // 请求头的 Key
+    string value = 2; // 请求头的 Value
+  }
+  
   optional string url = 1; // 下载文件的URL 二选一
   optional string base64 = 2; // 下载文件的base64 二选一
   optional string root_path = 3; // 下载文件的根目录 需要保证Kritor有该目录访问权限 可选
   optional string file_name = 4; // 保存的文件名称 默认为文件MD5 可选
   optional uint32 thread_cnt = 5; // 下载文件的线程数 默认为3 可选
-  optional string headers = 6; // 下载文件的请求头 可选
+  repeated Heander headers = 6; // 下载文件的请求头 可选
 }
 
 message DownloadFileResponse {
@@ -65,14 +70,6 @@ message DownloadFileResponse {
 > `root_path`需要保证Kritor有该目录访问权限，否则会报错。
 > 
 > `file_name`默认为文件MD5，如果你需要指定文件名，请填写。
-
-#### Headers示例
-
-`[\r\n]` 为分隔符，用于分隔多个头部字。
-
-```json
-"User-Agent=YOUR_UA[\r\n]Referer=https://www.baidu.com"
-```
 
 ## 获取当前账户
 

--- a/docs/request/friend.md
+++ b/docs/request/friend.md
@@ -19,33 +19,31 @@
 
 ```protobuf
 message FriendInfo {
-  string uid = 1; // uid 'u_*********'
-  uint64 uin = 2; // qq 如果没有可不提供
-  string qid = 3; // qid 用户自定义的qid 如若没有则为空
+  string user_id = 1;  // qq
+  string qid = 2;      // qid 用户自定义的qid 如若没有则为空
+  string nick = 3;     // 名称
+  string remark = 4;   // 备注
+  uint32 level = 5;    // 等级
+  uint32 age = 6;      // 年龄
+  uint32 vote_cnt = 7; // 赞数量
+  int32 gender = 8;    // 性别 可不提供
+  int32 group_id = 9;  // 好友分组id
+  optional string uid = 10; // uid 'u_*********'
 
-  string nick = 4;     // 名称
-  string remark = 5;   // 备注
-  uint32 level = 6;    // 等级
-  uint32 age = 7;      // 年龄
-  uint32 vote_cnt = 8; // 赞数量
-  int32 gender = 9;    // 性别 可不提供
-  int32 group_id = 10; // 好友分组id
-
-  
   optional ExtInfo ext = 99; // 扩展信息，根据协议平台提供的扩展信息
 }
 
 message ProfileCard {
-  string uid = 1;
-  uint64 uin = 2;
-  string qid = 3;
+  string user_id = 1;
+  string qid = 2;
+  string nick = 3;
+  optional string remark = 4;
+  uint32 level = 5;
+  optional uint64 birthday = 6;
+  uint32 login_day = 7; // 登录天数
+  uint32 vote_cnt = 8;  // 点赞数
 
-  string nick = 4;
-  optional string remark = 5;
-  uint32 level = 6;
-  optional uint64 birthday = 7;
-  uint32 login_day = 8; // 登录天数
-  uint32 vote_cnt = 9;  // 点赞数
+  optional string uid = 10; // uid 'u_*********'
 
   /* 以下字段可以不实现 */
   optional bool is_school_verified = 51;

--- a/docs/request/group.md
+++ b/docs/request/group.md
@@ -41,19 +41,20 @@ message NotJoinedGroupInfo {
 }
 
 message ProhibitedUserInfo {
-  string uid = 1;
-  uint64 uin = 2;
-  uint32 prohibited_time = 3;
+  string user_id = 1;
+  uint64 prohibited_time = 2;
+  optional string uid = 3;
 }
 
 message GroupHonorInfo {
-  string uid = 1; // 荣誉成员uid
-  uint64 uin = 2; // 荣誉成员uin
-  string nick = 3; // 荣誉成员昵称
-  string honor_name = 4; // 荣誉名称
-  string avatar = 5; // 荣誉图标url
-  uint32 id = 6; // 荣誉id
-  string description = 7; // 荣誉描述
+  string user_id = 1; // 荣誉成员qq
+  string nick = 2; // 荣誉成员昵称
+  string honor_name = 3; // 荣誉名称
+  string avatar = 4; // 荣誉图标url
+  uint32 id = 5; // 荣誉id
+  string description = 6; // 荣誉描述
+
+  optional string uid = 7; // 荣誉成员uid
 }
 
 enum MemberRole {
@@ -64,18 +65,18 @@ enum MemberRole {
 }
 
 message GroupMemberInfo {
-  string uid = 1;
-  uint64 uin = 2;
-  string nick = 3;
-  uint32 age = 4;
-  string unique_title = 5;
-  uint32 unique_title_expire_time = 6;
-  string card = 7;
-  uint64 join_time = 8;
-  uint64 last_active_time = 9;
-  uint32 level = 10;
-  uint64 shut_up_timestamp = 11;
+  string user_id = 1;
+  string nick = 2;
+  uint32 age = 3;
+  string unique_title = 4;
+  uint64 unique_title_expire_time = 5;
+  string card = 6;
+  uint64 join_time = 7;
+  uint64 last_active_time = 8;
+  uint32 level = 9;
+  uint64 shut_up_time = 10;
 
+  optional string uid = 11;
   optional uint32 distance = 100;
   repeated uint32 honors = 101;
   optional bool unfriendly = 102;
@@ -385,11 +386,8 @@ message GetGroupListResponse {
 ```protobuf
 message GetGroupMemberInfoRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string uid = 2; // 目标uid
-    uint64 uin = 3; // 目标uin
-  }
-  optional bool refresh = 4; // 是否刷新缓存
+  string user_id = 2; // 用户ID
+  optional bool refresh = 3; // 是否刷新缓存
 }
 
 message GetGroupMemberInfoResponse {
@@ -434,9 +432,9 @@ message GetGroupMemberListResponse {
 
 ```protobuf
 message ProhibitedUserInfo {
-  string uid = 1;
-  uint64 uin = 2;
-  uint32 prohibited_time = 3;
+  string user_id = 1;
+  uint64 prohibited_time = 2;
+  optional string uid = 3;
 }
 
 message GetProhibitedUserListRequest {
@@ -521,13 +519,14 @@ message GetNotJoinedGroupInfoResponse {
 
 ```protobuf
 message GroupHonorInfo {
-  string uid = 1; // 荣誉成员uid
-  uint64 uin = 2; // 荣誉成员uin
-  string nick = 3; // 荣誉成员昵称
-  string honor_name = 4; // 荣誉名称
-  string avatar = 5; // 荣誉图标url
-  uint32 id = 6; // 荣誉id
-  string description = 7; // 荣誉描述
+  string user_id = 1; // 荣誉成员qq
+  string nick = 2; // 荣誉成员昵称
+  string honor_name = 3; // 荣誉名称
+  string avatar = 4; // 荣誉图标url
+  uint32 id = 5; // 荣誉id
+  string description = 6; // 荣誉描述
+
+  optional string uid = 7; // 荣誉成员uid
 }
 
 message GetGroupHonorRequest {

--- a/docs/request/group.md
+++ b/docs/request/group.md
@@ -99,11 +99,8 @@ message GroupMemberInfo {
 ```protobuf
 message BanMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被禁言目标uid
-    uint64 target_uin = 3; // 被禁言目标uin
-  }
-  uint64 duration = 4; // 禁言时长(单位：秒)
+  string target_id = 2; // 被禁言目标qq号
+  uint32 duration = 3; // 单位：秒
 }
 
 message BanMemberResponse {
@@ -125,11 +122,9 @@ message BanMemberResponse {
 ```protobuf
 message PokeMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被戳目标uid
-    uint64 target_uin = 3; // 被戳目标uin
-  }
+  string target_id = 2; // 被戳一戳目标qq号
 }
+
 
 message PokeMemberResponse {
 }
@@ -150,11 +145,9 @@ message PokeMemberResponse {
 ```protobuf
 message KickMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被踢目标uid
-    uint64 target_uin = 3; // 被踢目标uin
-  }
-  optional bool reject_add_request = 4; // 是否拒绝再次申请 默认false
+  string target_id = 2; // 被踢出目标qq号
+  
+  optional bool reject_add_request = 6; // 是否拒绝再次申请 默认false
   optional string kick_reason = 5; // 踢出原因，可选
 }
 
@@ -198,11 +191,8 @@ message LeaveGroupResponse {
 ```protobuf
 message ModifyMemberCardRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  string card = 4; // 新的群名片
+  string target_id = 2; // 目标qq号
+  string card = 3; // 新的群名片
 }
 
 message ModifyMemberCardResponse {
@@ -268,11 +258,8 @@ message ModifyGroupRemarkResponse {
 ```protobuf
 message SetGroupAdminRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  bool is_admin = 4; // 是否设置为管理员
+  string target_id = 2; // 目标qq号
+  bool is_admin = 3; // 是否设置为管理员
 }
 
 message SetGroupAdminResponse {
@@ -294,11 +281,8 @@ message SetGroupAdminResponse {
 ```protobuf
 message SetGroupUniqueTitleRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  string unique_title = 4; // 新的群头衔
+  string target_id = 2; // 目标qq号
+  string unique_title = 3; // 新的群头衔
 }
 
 message SetGroupUniqueTitleResponse {

--- a/protos/common/contact.proto
+++ b/protos/common/contact.proto
@@ -38,8 +38,8 @@ message Contact {
 }
 
 message Sender {
-  string uid = 1;
-  optional uint64 uin = 2;
+  uint64 uin = 1;
+  optional string uid = 2;
   optional string nick = 3;
   optional Role role = 4;
 }

--- a/protos/common/contact.proto
+++ b/protos/common/contact.proto
@@ -33,12 +33,12 @@ enum Role {
 
 message Contact {
   Scene scene = 1;
-  string peer = 2; // GROUP: group_id, FRIEND|STRANGER_FROM_GROUP|NEARBY|STRANGER: uid, GUILD: guild_id
+  string peer = 2; // GROUP: group_id, FRIEND|STRANGER_FROM_GROUP|NEARBY|STRANGER: qq, GUILD: guild_id
   optional string sub_peer = 3; // GUILD: channel_id, STRANGER_FROM_GROUP: group_id
 }
 
 message Sender {
-  uint64 uin = 1;
+  string user_id = 1; // qq
   optional string uid = 2;
   optional string nick = 3;
   optional Role role = 4;

--- a/protos/common/message_data.proto
+++ b/protos/common/message_data.proto
@@ -34,15 +34,13 @@ message ForwardMessageBody {
 
 message EssenceMessageBody {
   uint32 group_id = 1;
-  string sender_uid = 2;
-  uint64 sender_uin = 3;
-  string sender_nick = 4;
-  uint64 operator_uid = 5;
-  uint64 operator_uin = 6;
-  string operator_nick = 7;
-  uint64 operation_time = 8;
-  uint64 message_time = 9;
-  string message_id = 10;
-  uint64 message_seq = 11;
-  string json_elements = 12;
+  string sender_id = 2;
+  string sender_nick = 3;
+  uint64 operator_id = 4;
+  string operator_nick = 5;
+  uint64 operation_time = 6;
+  uint64 message_time = 7;
+  string message_id = 8;
+  uint64 message_seq = 9;
+  string json_elements = 10;
 }

--- a/protos/common/message_element.proto
+++ b/protos/common/message_element.proto
@@ -80,8 +80,7 @@ message TextElement {
 }
 
 message AtElement {
-  string uid = 1; // 全体成员这里请写all
-  optional uint64 uin = 2;
+  string user_id = 1; // 全体成员这里请写all
 }
 
 message FaceElement {

--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -30,12 +30,17 @@ message GetVersionResponse {
 }
 
 message DownloadFileRequest {
+  message Header {
+    string key = 1; // 请求头的 Key
+    string value = 2; // 请求头的 Value
+  }
+  
   optional string url = 1; // 下载文件的URL 二选一
   optional string base64 = 2; // 下载文件的base64 二选一
   optional string root_path = 3; // 下载文件的根目录 需要保证Kritor有该目录访问权限 可选
   optional string file_name = 4; // 保存的文件名称 默认为文件MD5 可选
   optional uint32 thread_cnt = 5; // 下载文件的线程数 默认为3 可选
-  optional string headers = 6; // 下载文件的请求头 可选
+  repeated Heander headers = 6; // 下载文件的请求头 可选
 }
 
 message DownloadFileResponse {

--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -40,7 +40,7 @@ message DownloadFileRequest {
   optional string root_path = 3; // 下载文件的根目录 需要保证Kritor有该目录访问权限 可选
   optional string file_name = 4; // 保存的文件名称 默认为文件MD5 可选
   optional uint32 thread_cnt = 5; // 下载文件的线程数 默认为3 可选
-  repeated Heander headers = 6; // 下载文件的请求头 可选
+  repeated Header headers = 6; // 下载文件的请求头 可选
 }
 
 message DownloadFileResponse {

--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -52,13 +52,13 @@ message GetCurrentAccountRequest {
 }
 
 message GetCurrentAccountResponse {
-  string account_uid = 1; // 当前账户
-  uint64 account_uin = 2;
-  string account_name = 3; // 当前账户名称
+  string account_uin = 1; // 当前账户
+  string account_name = 2; // 当前账户名称
+  optional string account_uid = 3; // 当前账户uid
 }
 
 message SwitchAccountRequest {
-  oneof account {
+  oneof account { // 暂时保持不动 待后续商讨确认
     string account_uid = 1; // 切换账户uid
     uint64 account_uin = 2; // 切换账户uin
   }

--- a/protos/event/notice_data.proto
+++ b/protos/event/notice_data.proto
@@ -14,88 +14,75 @@ option java_package = "io.kritor.event";
 option go_package = "grpc/kritor/event";
 
 message PrivatePokeNotice {
-  string operator_uid = 1;
-  uint64 operator_uin = 2;
-  string action = 3;
-  string suffix = 4;
-  string action_image = 5;
+  string operator_id = 1;
+  string action = 2;
+  string suffix = 3;
+  string action_image = 4;
 }
 
 message PrivateRecallNotice {
-  string operator_uid = 1;
-  uint64 operator_uin = 2;
-  string message_id = 3;
-  string tip_text = 4;
+  string operator_id = 1;
+  string message_id = 2;
+  string tip_text = 3;
 }
 
 message PrivateFileUploadedNotice {
-  string operator_uid = 1;
-  uint64 operator_uin = 2;
-  string file_id = 3;
-  int32 file_sub_id = 4;
-  string file_name = 5;
-  uint64 file_size = 6;
-  uint64 expire_time = 7;
-  string file_url = 8;
+  string operator_id = 1;
+  string file_id = 2;
+  int32 file_sub_id = 3;
+  string file_name = 4;
+  uint64 file_size = 5;
+  uint64 expire_time = 6;
+  string file_url = 7;
 }
 
 message GroupPokeNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  string action = 6;
-  string suffix = 7;
-  string action_image = 8;
+  string operator_id = 2;
+  string target_id = 3;
+  string action = 4;
+  string suffix = 5;
+  string action_image = 6;
 }
 
 message GroupRecallNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  string message_id = 6;
-  string tip_text = 7;
+  string operator_id = 2;
+  string target_id = 3;
+  string message_id = 4;
+  string tip_text = 5;
 }
 
 message GroupFileUploadedNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string file_id = 4;
-  string file_name = 5;
-  uint64 file_size = 6;
-  int32 file_sub_id = 7;
-  uint64 expire_time = 8;
-  string file_url = 9;
+  string operator_id = 2;
+  string file_id = 3;
+  string file_name = 4;
+  uint64 file_size = 5;
+  int32 file_sub_id = 6;
+  uint64 expire_time = 7;
+  string file_url = 8;
 }
 
 message GroupCardChangedNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  string new_card = 6;
+  string operator_id = 2;
+  string target_id = 3;
+  string new_card = 4;
 }
 
 message GroupUniqueTitleChangedNotice {
   uint64 group_id = 1;
-  string target_uid = 2;
-  uint64 target_uin = 3;
-  string title = 4;
+  string target_id = 2;
+  string title = 3;
 }
 
 message GroupEssenceMessageNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  string message_id = 6;
-  bool is_set = 7;
+  string operator_id = 2;
+  string target_id = 3;
+  string message_id = 4;
+  bool is_set = 5;
 }
 
 message GroupMemberIncreasedNotice {
@@ -105,10 +92,9 @@ message GroupMemberIncreasedNotice {
   }
 
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
+  string operator_id = 2;
+  string target_id = 3;
+
   GroupMemberIncreasedType type = 6;
 }
 
@@ -120,26 +106,22 @@ message GroupMemberDecreasedNotice {
   }
   
   uint64 group_id = 1;
-  optional string operator_uid = 2; // 当 type 不为 LEAVE 时提供
-  optional uint64 operator_uin = 3;
-  optional string target_uid = 4; // 当 type 不为 KICK_ME 时提供
-  optional uint64 target_uin = 5;
-  GroupMemberDecreasedType type = 6;
+  optional string operator_id = 2; // 当 type 不为 LEAVE 时提供
+  optional string target_id = 3; // 当 type 不为 KICK_ME 时提供
+  GroupMemberDecreasedType type = 4;
 }
 
 message GroupAdminChangedNotice {
   uint64 group_id = 1;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  bool is_admin = 6;
+  string target_id = 4;
+  bool is_admin = 5;
 }
 
 message GroupSignInNotice {
   uint64 group_id = 1;
-  string target_uid = 2;
-  uint64 target_uin = 3;
-  string action = 4;
-  string rank_image = 6;
+  string target_id = 2;
+  string action = 3;
+  string rank_image = 5;
 }
 
 message GroupMemberBanNotice {
@@ -149,19 +131,16 @@ message GroupMemberBanNotice {
   }
   
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
-  int32 duration = 6;
-  GroupMemberBanType type = 7;
+  string operator_id = 2;
+  string target_id = 3;
+  int32 duration = 4;
+  GroupMemberBanType type = 5;
 }
 
 message GroupWholeBanNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  bool is_ban = 4;
+  string operator_id = 2;
+  bool is_ban = 3;
 }
 
 message GroupReactMessageWithEmojiNotice {
@@ -173,20 +152,16 @@ message GroupReactMessageWithEmojiNotice {
 
 message GroupTransferNotice {
   uint64 group_id = 1;
-  string operator_uid = 2;
-  uint64 operator_uin = 3;
-  string target_uid = 4;
-  uint64 target_uin = 5;
+  string operator_id = 2;
+  string target_id = 3;
 }
 
 message FriendIncreasedNotice {
-  string friend_uid = 1;
-  uint64 friend_uin = 2;
-  optional string friend_nick = 3;
+  string friend_id = 1;
+  optional string friend_nick = 2;
 }
 
 message FriendDecreasedNotice {
-  string friend_uid = 1;
-  uint64 friend_uin = 2;
-  optional string friend_nick = 3;
+  string friend_id = 1;
+  optional string friend_nick = 2;
 }

--- a/protos/event/request_data.proto
+++ b/protos/event/request_data.proto
@@ -14,22 +14,18 @@ option java_package = "io.kritor.event";
 option go_package = "grpc/kritor/event";
 
 message FriendApplyRequest {
-  string applier_uid = 1;
-  uint64 applier_uin = 2;
-  string message = 3;
+  string applier_id = 1;
+  string message = 2;
 }
 
 message GroupApplyRequest {
   uint64 group_id = 1;
-  string applier_uid = 2;
-  uint64 applier_uin = 3;
-  string inviter_uid = 4;
-  uint64 inviter_uin = 5;
-  string reason = 6;
+  uint64 applier_id = 2;
+  uint64 inviter_id = 3;
+  string reason = 4;
 }
 
 message InvitedJoinGroupRequest {
   uint64 group_id = 1;
-  string inviter_uid = 2;
-  uint64 inviter_uin = 3;
+  string inviter_id = 2;
 }

--- a/protos/friend/firend_data.proto
+++ b/protos/friend/firend_data.proto
@@ -14,33 +14,31 @@ option java_package = "io.kritor.friend";
 option go_package = "grpc/kritor/friend";
 
 message FriendInfo {
-  string uid = 1; // uid 'u_*********'
-  uint64 uin = 2; // qq 如果没有可不提供
-  string qid = 3; // qid 用户自定义的qid 如若没有则为空
+  string user_id = 1;  // qq
+  string qid = 2;      // qid 用户自定义的qid 如若没有则为空
+  string nick = 3;     // 名称
+  string remark = 4;   // 备注
+  uint32 level = 5;    // 等级
+  uint32 age = 6;      // 年龄
+  uint32 vote_cnt = 7; // 赞数量
+  int32 gender = 8;    // 性别 可不提供
+  int32 group_id = 9;  // 好友分组id
+  optional string uid = 10; // uid 'u_*********'
 
-  string nick = 4;     // 名称
-  string remark = 5;   // 备注
-  uint32 level = 6;    // 等级
-  uint32 age = 7;      // 年龄
-  uint32 vote_cnt = 8; // 赞数量
-  int32 gender = 9;    // 性别 可不提供
-  int32 group_id = 10; // 好友分组id
-
-  
   optional ExtInfo ext = 99; // 扩展信息，根据协议平台提供的扩展信息
 }
 
 message ProfileCard {
-  string uid = 1;
-  uint64 uin = 2;
-  string qid = 3;
+  string user_id = 1;
+  string qid = 2;
+  string nick = 3;
+  optional string remark = 4;
+  uint32 level = 5;
+  optional uint64 birthday = 6;
+  uint32 login_day = 7; // 登录天数
+  uint32 vote_cnt = 8;  // 点赞数
 
-  string nick = 4;
-  optional string remark = 5;
-  uint32 level = 6;
-  optional uint64 birthday = 7;
-  uint32 login_day = 8; // 登录天数
-  uint32 vote_cnt = 9;  // 点赞数
+  optional string uid = 10; // uid 'u_*********'
 
   /* 以下字段可以不实现 */
   optional bool is_school_verified = 51;

--- a/protos/friend/friend.proto
+++ b/protos/friend/friend.proto
@@ -71,10 +71,7 @@ message SetProfileCardResponse {
 }
 
 message IsBlackListUserRequest {
-  oneof target {
-    string target_uid = 1;
-    uint64 target_uin = 2;
-  }
+  string target_id = 1;
 }
 
 message IsBlackListUserResponse {
@@ -82,11 +79,8 @@ message IsBlackListUserResponse {
 }
 
 message VoteUserRequest {
-  oneof target {
-    string target_uid = 1;
-    uint64 target_uin = 2;
-  }
-  uint32 vote_count = 3;
+  string target_id = 1;
+  uint32 vote_count = 2;
 }
 
 message VoteUserResponse {

--- a/protos/group/group.proto
+++ b/protos/group/group.proto
@@ -162,11 +162,8 @@ message GetGroupListResponse {
 
 message GetGroupMemberInfoRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 获取目标uid
-    uint64 target_uin = 3; // 获取目标uin
-  }
-  optional bool refresh = 4; // 是否刷新缓存
+  string user_id = 2; // 用户ID
+  optional bool refresh = 3; // 是否刷新缓存
 }
 
 message GetGroupMemberInfoResponse {

--- a/protos/group/group.proto
+++ b/protos/group/group.proto
@@ -42,11 +42,8 @@ service GroupService {
 
 message BanMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被禁言目标uid
-    uint64 target_uin = 3; // 被禁言目标uin
-  }
-  uint32 duration = 4; // 单位：秒
+  string target_id = 2; // 被禁言目标qq号
+  uint32 duration = 3; // 单位：秒
 }
 
 message BanMemberResponse {
@@ -55,10 +52,7 @@ message BanMemberResponse {
 
 message PokeMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被戳一戳目标uid
-    uint64 target_uin = 3; // 被戳一戳目标uin
-  }
+  string target_id = 2; // 被戳一戳目标qq号
 }
 
 message PokeMemberResponse {
@@ -66,10 +60,8 @@ message PokeMemberResponse {
 
 message KickMemberRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 被踢出目标uid
-    uint64 target_uin = 3; // 被踢出目标uin
-  }
+  string target_id = 2; // 被踢出目标qq号
+  
   optional bool reject_add_request = 6; // 是否拒绝再次申请 默认false
   optional string kick_reason = 5; // 踢出原因，可选
 }
@@ -86,11 +78,8 @@ message LeaveGroupResponse {
 
 message ModifyMemberCardRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  string card = 4; // 新的群名片
+  string target_id = 2; // 目标qq号
+  string card = 3; // 新的群名片
 }
 
 message ModifyMemberCardResponse {
@@ -114,11 +103,8 @@ message ModifyGroupRemarkResponse {
 
 message SetGroupAdminRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  bool is_admin = 4; // 是否设置为管理员
+  string target_id = 2; // 目标qq号
+  bool is_admin = 3; // 是否设置为管理员
 }
 
 message SetGroupAdminResponse {
@@ -126,11 +112,8 @@ message SetGroupAdminResponse {
 
 message SetGroupUniqueTitleRequest {
   uint64 group_id = 1; // 群组ID
-  oneof target{
-    string target_uid = 2; // 目标uid
-    uint64 target_uin = 3; // 目标uin
-  }
-  string unique_title = 4; // 新的群头衔
+  string target_id = 2; // 目标qq号
+  string unique_title = 3; // 新的群头衔
 }
 
 message SetGroupUniqueTitleResponse {

--- a/protos/group/group_data.proto
+++ b/protos/group/group_data.proto
@@ -38,19 +38,20 @@ message NotJoinedGroupInfo {
 }
 
 message ProhibitedUserInfo {
-  string uid = 1;
-  uint64 uin = 2;
-  uint64 prohibited_time = 3;
+  string user_id = 1;
+  uint64 prohibited_time = 2;
+  optional string uid = 3;
 }
 
 message GroupHonorInfo {
-  string uid = 1; // 荣誉成员uid
-  uint64 uin = 2; // 荣誉成员uin
-  string nick = 3; // 荣誉成员昵称
-  string honor_name = 4; // 荣誉名称
-  string avatar = 5; // 荣誉图标url
-  uint32 id = 6; // 荣誉id
-  string description = 7; // 荣誉描述
+  string user_id = 1; // 荣誉成员qq
+  string nick = 2; // 荣誉成员昵称
+  string honor_name = 3; // 荣誉名称
+  string avatar = 4; // 荣誉图标url
+  uint32 id = 5; // 荣誉id
+  string description = 6; // 荣誉描述
+
+  optional string uid = 7; // 荣誉成员uid
 }
 
 enum MemberRole {
@@ -61,18 +62,18 @@ enum MemberRole {
 }
 
 message GroupMemberInfo {
-  string uid = 1;
-  uint64 uin = 2;
-  string nick = 3;
-  uint32 age = 4;
-  string unique_title = 5;
-  uint64 unique_title_expire_time = 6;
-  string card = 7;
-  uint64 join_time = 8;
-  uint64 last_active_time = 9;
-  uint32 level = 10;
-  uint64 shut_up_time = 11;
+  string user_id = 1;
+  string nick = 2;
+  uint32 age = 3;
+  string unique_title = 4;
+  uint64 unique_title_expire_time = 5;
+  string card = 6;
+  uint64 join_time = 7;
+  uint64 last_active_time = 8;
+  uint32 level = 9;
+  uint64 shut_up_time = 10;
 
+  optional string uid = 11;
   optional uint32 distance = 100;
   repeated uint32 honors = 101;
   optional bool unfriendly = 102;


### PR DESCRIPTION
**这是一项草案，需要更多的商讨**

经一段时间的使用和探讨，决定将uid改为可选字段、舍弃部分api的uid字段传参。

原因如下:
1. 在某些特定接口同时存在uid和uin参数的情况下，使用容易造成混淆。
2. 在uin为可选字段的标准中，uin很难作为唯一id来进行存储，标记等。
3. 在QQ平台上，uid只能使用非正常手段才可获取到对应的uin，而uin可直接在官方客户端进行搜索。